### PR TITLE
Tesse ttg backports

### DIFF
--- a/parsec/class/list.h
+++ b/parsec/class/list.h
@@ -1154,6 +1154,9 @@ parsec_list_nolock_pop_front( parsec_list_t* list )
 static inline parsec_list_item_t*
 parsec_list_pop_front( parsec_list_t* list )
 {
+    if( parsec_list_nolock_is_empty(list) ) {
+        return NULL;
+    }
     parsec_atomic_lock(&list->atomic_lock);
     parsec_list_item_t* item = parsec_list_nolock_pop_front(list);
     parsec_atomic_unlock(&list->atomic_lock);
@@ -1163,6 +1166,9 @@ parsec_list_pop_front( parsec_list_t* list )
 static inline parsec_list_item_t*
 parsec_list_try_pop_front( parsec_list_t* list)
 {
+    if( parsec_list_nolock_is_empty(list) ) {
+        return NULL;
+    }
     if( !parsec_atomic_trylock(&list->atomic_lock) ) {
         return NULL;
     }
@@ -1184,6 +1190,9 @@ parsec_list_nolock_pop_back( parsec_list_t* list )
 static inline parsec_list_item_t*
 parsec_list_pop_back( parsec_list_t* list )
 {
+    if( parsec_list_nolock_is_empty(list) ) {
+        return NULL;
+    }
     parsec_atomic_lock(&list->atomic_lock);
     parsec_list_item_t* item = parsec_list_nolock_pop_back(list);
     parsec_atomic_unlock(&list->atomic_lock);
@@ -1193,6 +1202,9 @@ parsec_list_pop_back( parsec_list_t* list )
 static inline parsec_list_item_t*
 parsec_list_try_pop_back( parsec_list_t* list)
 {
+    if( parsec_list_nolock_is_empty(list) ) {
+        return NULL;
+    }
     if( !parsec_atomic_trylock(&list->atomic_lock) ) {
         return NULL;
     }

--- a/parsec/class/list.h
+++ b/parsec/class/list.h
@@ -680,9 +680,13 @@ parsec_list_nolock_unchain( parsec_list_t* list );
 #define _TAIL(LIST) ((LIST)->ghost_element.list_prev)
 #define _GHOST(LIST) (&((list)->ghost_element))
 
+#if defined(PARSEC_DEBUG_PARANOID)
 #define _LIST_CHECK_CONSISTENCY(list)                                                 \
     assert( ((_HEAD(list) != _GHOST(list)) && (_TAIL(list) != _GHOST(list))) || \
             ((_HEAD(list) == _GHOST(list)) && (_TAIL(list) == _GHOST(list))) )
+#else
+#define _LIST_CHECK_CONSISTENCY(list)
+#endif  /* defined(PARSEC_DEBUG_PARANOID) */
 
 static inline int
 parsec_list_nolock_is_empty( parsec_list_t* list )

--- a/parsec/class/parsec_hash_table.c
+++ b/parsec/class/parsec_hash_table.c
@@ -89,7 +89,6 @@ int parsec_hash_tables_init(void)
 
 void parsec_hash_table_init(parsec_hash_table_t *ht, int64_t offset, int nb_bits, parsec_key_fn_t key_functions, void *data)
 {
-    parsec_atomic_lock_t unlocked = PARSEC_ATOMIC_UNLOCKED;
     parsec_atomic_rwlock_t unlock = { PARSEC_RWLOCK_UNLOCKED };
     parsec_hash_table_head_t *head;
     size_t i;
@@ -124,7 +123,7 @@ void parsec_hash_table_init(parsec_hash_table_t *ht, int64_t offset, int nb_bits
     ht->rw_lock        = unlock;
 
     for( i = 0; i < (1ULL<<nb_bits); i++) {
-        head->buckets[i].lock = unlocked;
+        parsec_atomic_lock_init(&head->buckets[i].lock);
         head->buckets[i].cur_len = 0;
         head->buckets[i].first_item = NULL;
     }

--- a/parsec/class/parsec_lifo.c
+++ b/parsec/class/parsec_lifo.c
@@ -27,10 +27,7 @@ static inline void parsec_lifo_construct( parsec_lifo_t* lifo )
     PARSEC_ITEM_ATTACH(lifo, lifo->lifo_ghost);
     lifo->lifo_head.data.item = lifo->lifo_ghost;
     lifo->lifo_head.data.guard.counter = 0;
-    /* We cannot use PARSEC_ATOMIC_UNLOCKED for not static initializers
-     * so instead we need to clear the state of the lock.
-     */
-    parsec_atomic_unlock(&lifo->lifo_head.data.guard.lock);
+    parsec_atomic_lock_init(&lifo->lifo_head.data.guard.lock);
 }
 
 static inline void parsec_lifo_destruct( parsec_lifo_t *lifo )

--- a/parsec/class/parsec_list.c
+++ b/parsec/class/parsec_list.c
@@ -36,7 +36,7 @@ parsec_list_construct( parsec_list_t* list )
     PARSEC_ITEM_ATTACH(list, &list->ghost_element);
     list->ghost_element.list_next = &list->ghost_element;
     list->ghost_element.list_prev = &list->ghost_element;
-    parsec_atomic_unlock(&list->atomic_lock);
+    parsec_atomic_lock_init(&list->atomic_lock);
 }
 
 static inline void

--- a/parsec/hbbuffer.c
+++ b/parsec/hbbuffer.c
@@ -53,7 +53,7 @@ parsec_hbbuffer_push_all(parsec_hbbuffer_t *b,
         PARSEC_LIST_ITEM_SINGLETON(elt);
         /* Try to find a room for elt */
         for(; (size_t)i < b->size; i++) {
-            if( 0 == parsec_atomic_cas_ptr(&b->items[i], NULL, elt) )
+            if( NULL != b->items[i] || 0 == parsec_atomic_cas_ptr(&b->items[i], NULL, elt) )
                 continue;
             PARSEC_DEBUG_VERBOSE(20, parsec_debug_output,  "HBB:\tPush elem %p in local queue %p at position %d", elt, b, i );
             /* Found an empty space to push the first element. */

--- a/parsec/include/parsec/sys/atomic-c11.h
+++ b/parsec/include/parsec/sys/atomic-c11.h
@@ -142,6 +142,13 @@ __int128_t parsec_atomic_fetch_add_int128(volatile __int128_t* l, __int128_t v)
 
 typedef volatile atomic_flag parsec_atomic_lock_t;
 
+#  define PARSEC_ATOMIC_HAS_ATOMIC_INIT
+ATOMIC_STATIC_INLINE
+void parsec_atomic_lock_init( parsec_atomic_lock_t* atomic_lock )
+{
+    atomic_flag_clear_explicit(atomic_lock, memory_order_relaxed);
+}
+
 #define PARSEC_ATOMIC_HAS_ATOMIC_LOCK
 ATOMIC_STATIC_INLINE
 void parsec_atomic_lock( parsec_atomic_lock_t* atomic_lock )

--- a/parsec/include/parsec/sys/atomic.h
+++ b/parsec/include/parsec/sys/atomic.h
@@ -254,6 +254,12 @@ __int128_t parsec_atomic_fetch_dec_int128(volatile __int128_t* l)
 #  if !defined(PARSEC_ATOMIC_HAS_ATOMIC_LOCK)
 typedef volatile int32_t parsec_atomic_lock_t;
 #  define PARSEC_ATOMIC_UNLOCKED 0
+#  define PARSEC_ATOMIC_HAS_ATOMIC_INIT
+ATOMIC_STATIC_INLINE
+void parsec_atomic_init( parsec_atomic_lock_t* atomic_lock )
+{
+    *atomic_lock = PARSEC_ATOMIC_UNLOCKED;
+}
 #  define PARSEC_ATOMIC_HAS_ATOMIC_LOCK
 ATOMIC_STATIC_INLINE
 void parsec_atomic_lock( parsec_atomic_lock_t* atomic_lock )

--- a/parsec/parsec.c
+++ b/parsec/parsec.c
@@ -107,6 +107,7 @@ static char *parsec_app_name = NULL;
 
 static int parsec_runtime_max_number_of_cores = -1;
 static int parsec_runtime_bind_main_thread = 1;
+static int parsec_runtime_bind_threads     = 1;
 
 PARSEC_TLS_DECLARE(parsec_tls_execution_stream);
 
@@ -189,7 +190,7 @@ static void* __parsec_thread_init( __parsec_temporary_thread_initialization_t* s
     int pi;
 
     /* don't use PARSEC_THREAD_IS_MASTER, it is too early and we cannot yet allocate the es struct */
-    if( (0 != startup->virtual_process->vp_id) || (0 != startup->th_id) || parsec_runtime_bind_main_thread ) {
+    if( parsec_runtime_bind_threads && ((0 != startup->virtual_process->vp_id) || (0 != startup->th_id) || parsec_runtime_bind_main_thread)) {
         /* Bind to the specified CORE */
         parsec_bindthread(startup->bindto, startup->bindto_ht);
         PARSEC_DEBUG_VERBOSE(10, parsec_debug_output, "Bind thread %i.%i on core %i [HT %i]",
@@ -461,6 +462,8 @@ parsec_context_t* parsec_init( int nb_cores, int* pargc, char** pargv[] )
     }
     parsec_mca_param_reg_int_name("runtime", "bind_main_thread", "Force the binding of the thread calling parsec_init",
                                  false, false, parsec_runtime_bind_main_thread, &parsec_runtime_bind_main_thread);
+    parsec_mca_param_reg_int_name("runtime", "bind_threads", "Bind main and worker threads", false, false,
+                                  parsec_runtime_bind_threads, &parsec_runtime_bind_threads);
 
     if( parsec_cmd_line_is_taken(cmd_line, "gpus") ) {
         parsec_warning("Option g (for accelerators) is deprecated as an argument. Use the MCA parameter instead.");

--- a/parsec/parsec_remote_dep.c
+++ b/parsec/parsec_remote_dep.c
@@ -2047,18 +2047,20 @@ remote_dep_dequeue_nothread_progress(parsec_execution_stream_t* es,
     }
     /* Extract the head of the list and point the array to the correct value */
     if(NULL == (item = (dep_cmd_item_t*)parsec_list_nolock_pop_front(&dep_cmd_fifo)) ) {
-        do {
-            ret = remote_dep_mpi_progress(es);
-        } while(ret);
+        if (context->nb_nodes > 1) {
+            do {
+                ret = remote_dep_mpi_progress(es);
+            } while(ret);
 
-        if( !ret
-         && ((comm_yield == 2)
-          || (comm_yield == 1
-           && !parsec_list_nolock_is_empty(&dep_activates_fifo)
-           && !parsec_list_nolock_is_empty(&dep_put_fifo))) ) {
-            struct timespec ts;
-            ts.tv_sec = 0; ts.tv_nsec = comm_yield_ns;
-            nanosleep(&ts, NULL);
+            if( !ret
+             && ((comm_yield == 2)
+              || (comm_yield == 1
+               && !parsec_list_nolock_is_empty(&dep_activates_fifo)
+               && !parsec_list_nolock_is_empty(&dep_put_fifo))) ) {
+                struct timespec ts;
+                ts.tv_sec = 0; ts.tv_nsec = comm_yield_ns;
+                nanosleep(&ts, NULL);
+            }
         }
         goto check_pending_queues;
     }

--- a/parsec/parsec_remote_dep.c
+++ b/parsec/parsec_remote_dep.c
@@ -22,7 +22,7 @@ int parsec_comm_gets      = 0;
 int parsec_comm_puts_max  = DEP_NB_CONCURENT * MAX_PARAM_COUNT;
 int parsec_comm_puts      = 0;
 
-static bool parsec_remote_dep_use_get = true;
+static int parsec_remote_dep_use_get = 0;
 
 /**
  * Number of data movements to be extracted at each step. Bigger the number
@@ -287,6 +287,9 @@ static void remote_dep_mpi_params(parsec_context_t* context) {
 #endif
     parsec_mca_param_reg_int_name("runtime", "comm_aggregate", "Aggregate multiple dependencies in the same short message (1=true,0=false).",
                                   false, false, parsec_param_enable_aggregate, &parsec_param_enable_aggregate);
+
+    parsec_mca_param_reg_int_name("runtime", "comm_get", "Use the PUT protocol (0) or the GET protocol (1) for transfering payload data.",
+                                  false, false, parsec_remote_dep_use_get, &parsec_remote_dep_use_get);
 }
 
 void

--- a/parsec/parsec_remote_dep.h
+++ b/parsec/parsec_remote_dep.h
@@ -51,6 +51,7 @@ typedef struct remote_dep_wire_activate_s {
     uint32_t             taskpool_id;
     uint32_t             task_class_id;
     uint32_t             length;
+    uintptr_t            callback_fn;     /** Only used for GET protocol */
     parsec_assignment_t  locals[MAX_LOCAL_COUNT];
 } remote_dep_wire_activate_t;
 
@@ -110,6 +111,8 @@ struct parsec_remote_deps_s {
     int32_t                          priority;
     uint32_t                        *remote_dep_fw_mask;  /**< list of peers already notified about
                                                             * the control sequence (only used for control messages) */
+    void                            *memhandles; /* used for the GET protocol to store the provided memory handles */
+    uintptr_t                        remote_cb_data; /* used for the GET protocol to store the provided cb data */
     struct data_repo_entry_s        *repo_entry;
     struct remote_dep_output_param_s output[1];
 };

--- a/parsec/profiling_otf2.c
+++ b/parsec/profiling_otf2.c
@@ -168,7 +168,8 @@ void parsec_profiling_add_information( const char *key, const char *value )
             *c = '_';
         }
     }
-    new_info->value = strdup(value);
+    /* OTF2 cannot handle empty property values so make them explicit */
+    new_info->value = (0 == strlen(value)) ? strdup("<empty>") : strdup(value);
     parsec_list_push_back(&global_informations, &new_info->super);
 }
 


### PR DESCRIPTION
Backporting a set of changes to the communication backend and termination detection that have proven useful in TTG. All of this is temporary until revamp has been merged. I will then integrate these changes, where appropriate.

Changes include:
- multi-threaded MPI backend (yes, it's still called funneled...)
- Sending of AMs as non-blocking sends (body is copied anyway, reduce blocking of calling thread)
- Usage of the GET protocol the remote dependency code (can be used with PTG, for comparison purposes)
- Removal of locks in four-counter critical path (merged upstream)
- Reduction of CAS operations in hbbuffer (upstream pending, soon)