### PR TITLE
Add the field priority in the properties defined by task profiling

### DIFF
--- a/parsec/interfaces/dtd/insert_function.c
+++ b/parsec/interfaces/dtd/insert_function.c
@@ -2537,6 +2537,7 @@ parsec_insert_dtd_task(parsec_task_t *__this_task)
         if( PARSEC_INOUT == (tile_op_type & PARSEC_GET_OP_TYPE) || PARSEC_OUTPUT == (tile_op_type & PARSEC_GET_OP_TYPE) ) {
 #if defined(PARSEC_PROF_TRACE)
             this_task->super.prof_info.desc = NULL;
+            this_task->super.prof_info.priority = this_task->super.priority;
             this_task->super.prof_info.data_id = tile->key;
             this_task->super.prof_info.task_class_id = tc->task_class_id;
 #endif

--- a/parsec/interfaces/dtd/parsec_dtd_data_flush.c
+++ b/parsec/interfaces/dtd/parsec_dtd_data_flush.c
@@ -150,6 +150,7 @@ parsec_insert_dtd_flush_task(parsec_dtd_task_t *this_task, parsec_dtd_tile_t *ti
 
 #if defined(PARSEC_PROF_TRACE)
     this_task->super.prof_info.desc = NULL;
+    this_task->super.prof_info.priority = 0;
     this_task->super.prof_info.data_id = tile->key;
     this_task->super.prof_info.task_class_id = tc->task_class_id;
 #endif

--- a/parsec/interfaces/ptg/ptg-compiler/jdf2c.c
+++ b/parsec/interfaces/ptg/ptg-compiler/jdf2c.c
@@ -6460,6 +6460,7 @@ jdf_generate_code_data_lookup(const jdf_t *jdf,
         coutput("  /** Generate profiling information */\n"
                 "#if defined(PARSEC_PROF_TRACE)\n"
                 "  this_task->prof_info.desc = (parsec_data_collection_t*)"TASKPOOL_GLOBAL_PREFIX"_g_%s;\n"
+                "  this_task->prof_info.priority = this_task->priority;\n"
                 "  this_task->prof_info.data_id   = ((parsec_data_collection_t*)"TASKPOOL_GLOBAL_PREFIX"_g_%s)->data_key((parsec_data_collection_t*)"TASKPOOL_GLOBAL_PREFIX"_g_%s, %s);\n"
                 "  this_task->prof_info.task_class_id = this_task->task_class->task_class_id;\n"
                 "  this_task->prof_info.task_return_code = -1;\n"

--- a/parsec/profiling.h
+++ b/parsec/profiling.h
@@ -423,12 +423,13 @@ typedef struct {
  */
 typedef struct {
     struct parsec_data_collection_s *desc;
+    int32_t                          priority;
     uint32_t                         data_id;
-    int16_t                          task_class_id;
-    int16_t                          task_return_code;
+    int32_t                          task_class_id;
+    int32_t                          task_return_code;
 } parsec_task_prof_info_t;    
 
-#define PARSEC_TASK_PROF_INFO_CONVERTOR "dc_key{uint64_t};dc_dataid{uint32_t};tcid{int16_t};trc{int16_t}"
+#define PARSEC_TASK_PROF_INFO_CONVERTOR "dc_key{uint64_t};priority{int32_t};dc_dataid{uint32_t};tcid{int32_t};trc{int32_t}"
 
 /**
  * @brief String used to identify GPU streams


### PR DESCRIPTION
Backport from PaRSEC's master branch to the TESSE branch.

upgrade task_class_id and return code to 32 bits each to fit structure padding.