### PR TITLE
Tesse ttg parsec nosideeffect

### DIFF
--- a/parsec/include/parsec/execution_stream.h
+++ b/parsec/include/parsec/execution_stream.h
@@ -39,6 +39,8 @@ struct parsec_execution_stream_s {
 
     pthread_t pthread_id;     /**< POSIX thread identifier. */
 
+    unsigned int rand_seed;   /**< Random seed local to this stream (to use in rand_r for example) */
+
 #if defined(PARSEC_PROF_TRACE)
     parsec_profiling_stream_t *es_profile;
 #endif /* PARSEC_PROF_TRACE */

--- a/parsec/mca/sched/rnd/sched_rnd_module.c
+++ b/parsec/mca/sched/rnd/sched_rnd_module.c
@@ -107,7 +107,7 @@ static int sched_rnd_schedule(parsec_execution_stream_t* es,
                 parsec_task_snprintf(tmp_str, MAX_TASK_STRLEN, (parsec_task_t*)it));
 #endif
         /* randomly assign priority */
-        (*((int*)(((uintptr_t)it)+parsec_execution_context_priority_comparator))) = rand() + distance;
+        (*((int*)(((uintptr_t)it)+parsec_execution_context_priority_comparator))) = rand_r(&es->rand_seed) + distance;
         it = (parsec_list_item_t*)((parsec_list_item_t*)it)->list_next;
     } while( it != (parsec_list_item_t*)new_context );
 

--- a/parsec/parsec.c
+++ b/parsec/parsec.c
@@ -186,6 +186,7 @@ static int parsec_parse_comm_binding_parameter(const char* option, parsec_contex
 static void* __parsec_thread_init( __parsec_temporary_thread_initialization_t* startup )
 {
     parsec_execution_stream_t* es;
+    struct timeval tv_now;
     int pi;
 
     /* don't use PARSEC_THREAD_IS_MASTER, it is too early and we cannot yet allocate the es struct */
@@ -206,11 +207,13 @@ static void* __parsec_thread_init( __parsec_temporary_thread_initialization_t* s
     if( NULL == es ) {
         return NULL;
     }
+    gettimeofday(&tv_now, NULL);
 
     PARSEC_TLS_SET_SPECIFIC(parsec_tls_execution_stream, es);
 
     es->th_id            = startup->th_id;
     es->virtual_process  = startup->virtual_process;
+    es->rand_seed        = tv_now.tv_usec + startup->th_id;
     es->scheduler_object = NULL;
     startup->virtual_process->execution_streams[startup->th_id] = es;
     es->core_id          = startup->bindto;

--- a/parsec/scheduling.c
+++ b/parsec/scheduling.c
@@ -355,10 +355,10 @@ int __parsec_reschedule(parsec_execution_stream_t* es, parsec_task_t* task)
 
 #define TIME_STEP 5410
 #define MIN(x, y) ( (x)<(y)?(x):(y) )
-static inline unsigned long exponential_backoff(uint64_t k)
+static inline unsigned long exponential_backoff(parsec_execution_stream_t *es, uint64_t k)
 {
     unsigned int n = MIN( 64, k );
-    unsigned int r = (unsigned int) ((double)n * ((double)rand()/(double)RAND_MAX));
+    unsigned int r = (unsigned int) ((double)n * ((double)rand_r(&es->rand_seed)/(double)RAND_MAX));
     return r * TIME_STEP;
 }
 
@@ -528,7 +528,7 @@ int __parsec_context_wait( parsec_execution_stream_t* es )
 #endif /* defined(DISTRIBUTED) */
 
         if( misses_in_a_row > 1 ) {
-            rqtp.tv_nsec = exponential_backoff(misses_in_a_row);
+            rqtp.tv_nsec = exponential_backoff(es, misses_in_a_row);
             nanosleep(&rqtp, NULL);
         }
         misses_in_a_row++;  /* assume we fail to extract a task */


### PR DESCRIPTION
This PR should go after https://github.com/TESSEorg/parsec/pull/14

This patch should be backported into master parsec: it is against the XSDK policies to have a side effect like we do on the status of other libraries like libc.
